### PR TITLE
fix: Add an __init__.py file.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@
 #
 asgiref==3.8.1
     # via django
-babel==2.14.0
+babel==2.16.0
     # via
     #   -r requirements/base.in
     #   enmerkar
@@ -14,18 +14,16 @@ backports-zoneinfo==0.2.1 ; python_version < "3.9"
     # via
     #   -c requirements/constraints.txt
     #   django
-django==4.2.11
+django==4.2.16
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
     #   enmerkar
 enmerkar==0.7.1
     # via -r requirements/base.in
-markey==0.8
-    # via -r requirements/base.in
 pytz==2024.1
     # via babel
-sqlparse==0.5.0
+sqlparse==0.5.1
     # via django
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via asgiref

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ alabaster==0.7.13
     # via sphinx
 asgiref==3.8.1
     # via django
-babel==2.14.0
+babel==2.16.0
     # via
     #   -r requirements/base.in
     #   enmerkar
@@ -17,16 +17,16 @@ backports-zoneinfo==0.2.1 ; python_version < "3.9"
     # via
     #   -c requirements/constraints.txt
     #   django
-certifi==2024.2.2
+certifi==2024.8.30
     # via requests
 charset-normalizer==3.3.2
     # via requests
-coverage[toml]==7.5.0
+coverage[toml]==7.6.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
     #   python-coveralls
-django==4.2.11
+django==4.2.16
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -35,31 +35,27 @@ docutils==0.20.1
     # via sphinx
 enmerkar==0.7.1
     # via -r requirements/base.in
-exceptiongroup==1.2.1
+exceptiongroup==1.2.2
     # via pytest
 execnet==2.1.1
     # via pytest-cache
-flake8==7.0.0
+flake8==7.1.1
     # via -r requirements/test.in
-idna==3.7
+idna==3.8
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.11.0
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   sphinx
+importlib-metadata==8.4.0
+    # via sphinx
 iniconfig==2.0.0
     # via pytest
-jinja2==3.1.3
+jinja2==3.1.4
     # via sphinx
-markey==0.8
-    # via -r requirements/base.in
 markupsafe==2.1.5
     # via jinja2
 mccabe==0.7.0
     # via flake8
-packaging==24.0
+packaging==24.1
     # via
     #   pytest
     #   sphinx
@@ -67,15 +63,15 @@ pep8==1.7.1
     # via pytest-pep8
 pluggy==1.5.0
     # via pytest
-pycodestyle==2.11.1
+pycodestyle==2.12.1
     # via flake8
 pyflakes==3.2.0
     # via
     #   flake8
     #   pytest-flakes
-pygments==2.17.2
+pygments==2.18.0
     # via sphinx
-pytest==8.1.1
+pytest==8.3.2
     # via
     #   -r requirements/test.in
     #   pytest-cache
@@ -94,9 +90,9 @@ python-coveralls==2.9.3
     # via -r requirements/test.in
 pytz==2024.1
     # via babel
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via python-coveralls
-requests==2.31.0
+requests==2.32.3
     # via
     #   python-coveralls
     #   sphinx
@@ -118,15 +114,15 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlparse==0.5.0
+sqlparse==0.5.1
     # via django
 tomli==2.0.1
     # via
     #   coverage
     #   pytest
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via asgiref
-urllib3==2.2.1
+urllib3==2.2.2
     # via requests
-zipp==3.18.1
+zipp==3.20.1
     # via importlib-metadata

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,15 +8,13 @@ build==1.2.1
     # via pip-tools
 click==8.1.7
     # via pip-tools
-importlib-metadata==6.11.0
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   build
-packaging==24.0
+importlib-metadata==8.4.0
+    # via build
+packaging==24.1
     # via build
 pip-tools==7.4.1
     # via -r requirements/pip-tools.in
-pyproject-hooks==1.0.0
+pyproject-hooks==1.1.0
     # via
     #   build
     #   pip-tools
@@ -24,10 +22,9 @@ tomli==2.0.1
     # via
     #   build
     #   pip-tools
-    #   pyproject-hooks
-wheel==0.43.0
+wheel==0.44.0
     # via pip-tools
-zipp==3.18.1
+zipp==3.20.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.43.0
+wheel==0.44.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.0
+pip==24.2
     # via -r requirements/pip.in
-setuptools==69.5.1
+setuptools==74.1.2
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,7 +8,7 @@ alabaster==0.7.13
     # via sphinx
 asgiref==3.8.1
     # via django
-babel==2.14.0
+babel==2.16.0
     # via
     #   -r requirements/base.in
     #   enmerkar
@@ -17,16 +17,16 @@ backports-zoneinfo==0.2.1 ; python_version < "3.9"
     # via
     #   -c requirements/constraints.txt
     #   django
-certifi==2024.2.2
+certifi==2024.8.30
     # via requests
 charset-normalizer==3.3.2
     # via requests
-coverage[toml]==7.5.0
+coverage[toml]==7.6.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
     #   python-coveralls
-django==4.2.11
+django==4.2.16
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -35,31 +35,27 @@ docutils==0.20.1
     # via sphinx
 enmerkar==0.7.1
     # via -r requirements/base.in
-exceptiongroup==1.2.1
+exceptiongroup==1.2.2
     # via pytest
 execnet==2.1.1
     # via pytest-cache
-flake8==7.0.0
+flake8==7.1.1
     # via -r requirements/test.in
-idna==3.7
+idna==3.8
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.11.0
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   sphinx
+importlib-metadata==8.4.0
+    # via sphinx
 iniconfig==2.0.0
     # via pytest
-jinja2==3.1.3
+jinja2==3.1.4
     # via sphinx
-markey==0.8
-    # via -r requirements/base.in
 markupsafe==2.1.5
     # via jinja2
 mccabe==0.7.0
     # via flake8
-packaging==24.0
+packaging==24.1
     # via
     #   pytest
     #   sphinx
@@ -67,15 +63,15 @@ pep8==1.7.1
     # via pytest-pep8
 pluggy==1.5.0
     # via pytest
-pycodestyle==2.11.1
+pycodestyle==2.12.1
     # via flake8
 pyflakes==3.2.0
     # via
     #   flake8
     #   pytest-flakes
-pygments==2.17.2
+pygments==2.18.0
     # via sphinx
-pytest==8.1.1
+pytest==8.3.2
     # via
     #   -r requirements/test.in
     #   pytest-cache
@@ -94,9 +90,9 @@ python-coveralls==2.9.3
     # via -r requirements/test.in
 pytz==2024.1
     # via babel
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via python-coveralls
-requests==2.31.0
+requests==2.32.3
     # via
     #   python-coveralls
     #   sphinx
@@ -118,15 +114,15 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlparse==0.5.0
+sqlparse==0.5.1
     # via django
 tomli==2.0.1
     # via
     #   coverage
     #   pytest
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via asgiref
-urllib3==2.2.1
+urllib3==2.2.2
     # via requests
-zipp==3.18.1
+zipp==3.20.1
     # via importlib-metadata

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -8,7 +8,7 @@ alabaster==0.7.13
     # via sphinx
 asgiref==3.8.1
     # via django
-babel==2.14.0
+babel==2.16.0
     # via
     #   -r requirements/base.in
     #   enmerkar
@@ -17,11 +17,11 @@ backports-zoneinfo==0.2.1 ; python_version < "3.9"
     # via
     #   -c requirements/constraints.txt
     #   django
-certifi==2024.2.2
+certifi==2024.8.30
     # via requests
 charset-normalizer==3.3.2
     # via requests
-coverage[toml]==7.5.0
+coverage[toml]==7.6.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -34,31 +34,27 @@ docutils==0.20.1
     # via sphinx
 enmerkar==0.7.1
     # via -r requirements/base.in
-exceptiongroup==1.2.1
+exceptiongroup==1.2.2
     # via pytest
 execnet==2.1.1
     # via pytest-cache
-flake8==7.0.0
+flake8==7.1.1
     # via -r requirements/test.in
-idna==3.7
+idna==3.8
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.11.0
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   sphinx
+importlib-metadata==8.4.0
+    # via sphinx
 iniconfig==2.0.0
     # via pytest
-jinja2==3.1.3
+jinja2==3.1.4
     # via sphinx
-markey==0.8
-    # via -r requirements/base.in
 markupsafe==2.1.5
     # via jinja2
 mccabe==0.7.0
     # via flake8
-packaging==24.0
+packaging==24.1
     # via
     #   pytest
     #   sphinx
@@ -66,15 +62,15 @@ pep8==1.7.1
     # via pytest-pep8
 pluggy==1.5.0
     # via pytest
-pycodestyle==2.11.1
+pycodestyle==2.12.1
     # via flake8
 pyflakes==3.2.0
     # via
     #   flake8
     #   pytest-flakes
-pygments==2.17.2
+pygments==2.18.0
     # via sphinx
-pytest==8.1.1
+pytest==8.3.2
     # via
     #   -r requirements/test.in
     #   pytest-cache
@@ -93,9 +89,9 @@ python-coveralls==2.9.3
     # via -r requirements/test.in
 pytz==2024.1
     # via babel
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via python-coveralls
-requests==2.31.0
+requests==2.32.3
     # via
     #   python-coveralls
     #   sphinx
@@ -117,15 +113,15 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlparse==0.5.0
+sqlparse==0.5.1
     # via django
 tomli==2.0.1
     # via
     #   coverage
     #   pytest
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via asgiref
-urllib3==2.2.1
+urllib3==2.2.2
     # via requests
-zipp==3.18.1
+zipp==3.20.1
     # via importlib-metadata

--- a/src/enmerkar_underscore/__init__.py
+++ b/src/enmerkar_underscore/__init__.py
@@ -14,7 +14,7 @@ from .vendor.markey import underscore
 from .vendor.markey.machine import parse_arguments, tokenize
 from .vendor.markey.tools import TokenStream
 
-__version__ = '2.3.0'
+__version__ = '2.3.1'
 
 def extract(fileobj, keywords, comment_tags, options):
     """Extracts translation messages from underscore template files.

--- a/src/enmerkar_underscore/vendor/markey/tests/test_machine.py
+++ b/src/enmerkar_underscore/vendor/markey/tests/test_machine.py
@@ -1,6 +1,6 @@
-from markey.machine import tokenize, parse_arguments
-from markey.tools import TokenStream
-from markey.underscore import rules as underscore_rules
+from enmerkar_underscore.vendor.markey.machine import tokenize, parse_arguments
+from enmerkar_underscore.vendor.markey.tools import TokenStream
+from enmerkar_underscore.vendor.markey.underscore import rules as underscore_rules
 
 
 def test_parse_arguments():

--- a/src/enmerkar_underscore/vendor/markey/tests/test_rules.py
+++ b/src/enmerkar_underscore/vendor/markey/tests/test_rules.py
@@ -1,6 +1,6 @@
 import re
 
-from markey.rules import bygroups, rule, ruleset
+from enmerkar_underscore.vendor.markey.rules import bygroups, rule, ruleset
 
 
 def test_bygroups():

--- a/src/enmerkar_underscore/vendor/markey/tests/test_tools.py
+++ b/src/enmerkar_underscore/vendor/markey/tests/test_tools.py
@@ -3,7 +3,7 @@ from six import StringIO
 
 import pytest
 
-from markey.tools import Token, TokenStream, TokenStreamIterator
+from enmerkar_underscore.vendor.markey.tools import Token, TokenStream, TokenStreamIterator
 
 
 def test_tokenstream():


### PR DESCRIPTION
The `vendor` package was missing this file, so the `find_packages`
command was not finding all the vendored file we wanted to include.
